### PR TITLE
Implement setting to install CLI package as bin

### DIFF
--- a/apps/cli/bin/cli
+++ b/apps/cli/bin/cli
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/index.js')

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,6 +11,9 @@
     "node": "16"
   },
   "main": "lib/index.js",
+  "bin": {
+    "@link-to-code/cli": "./bin/cli"
+  },
   "dependencies": {
     "@link-to-code/domain": "workspace:*",
     "commander": "~9.4.1",


### PR DESCRIPTION
## Description
Add missing bin setting in package json in order to let package manager know that it must be added to the bin folder when it is installed.
See documentation [here](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#bin).